### PR TITLE
feat: add double SHA2-256 hashing

### DIFF
--- a/src/crypto.js
+++ b/src/crypto.js
@@ -11,6 +11,15 @@ const toBuf = utils.toBuf
 const fromString = utils.fromString
 const fromNumberTo32BitBuf = utils.fromNumberTo32BitBuf
 
+const dblSha2256 = (buf, cb) => {
+  sha.sha2256(buf, (err, firstHash) => {
+    if (err) {
+      cb(err)
+    }
+    sha.sha2256((Buffer.from(firstHash)), cb)
+  })
+}
+
 module.exports = {
   sha1: sha.sha1,
   sha2256: sha.sha2256,
@@ -27,5 +36,6 @@ module.exports = {
   keccak512: toCallback(toBuf(sha3.keccak_512)),
   murmur3128: toCallback(toBuf(fromString(murmur3.x64.hash128))),
   murmur332: toCallback(fromNumberTo32BitBuf(fromString(murmur3.x86.hash32))),
-  addBlake: require('./blake')
+  addBlake: require('./blake'),
+  dblSha2256: dblSha2256
 }

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,9 @@ Multihashing.functions = {
   // murmur3-128
   0x22: crypto.murmur3128,
   // murmur3-32
-  0x23: crypto.murmur332
+  0x23: crypto.murmur332,
+  // dbl-sha2-256
+  0x56: crypto.dblSha2256
 }
 
 // add blake functions

--- a/test/fixtures/encodes.js
+++ b/test/fixtures/encodes.js
@@ -72,4 +72,8 @@ module.exports = [[
   'beep boop',
   'blake2s-256',
   'e0e402204542eaca484e4311def8af74b546edd7fceb49eeb3cdcfd8a4a72ed0dc81d4c0'
+], [
+  'beep boop',
+  'dbl-sha2-256',
+  '56209cd9115d76945c2455b1450295b05f4edeba2e7286bc24c23e266b48faf578c0'
 ]]


### PR DESCRIPTION
The double SHA2-256 is e.g. used for Bitcoin and Zcash.

Fixes #25.