### PR TITLE
Improve Error on missing webcrypto

### DIFF
--- a/src/crypto-sha1-2-browser.js
+++ b/src/crypto-sha1-2-browser.js
@@ -18,7 +18,7 @@ function getWebCrypto () {
 
 function webCryptoHash (type) {
   if (!webCrypto) {
-    throw new Error('Please use a browser with webcrypto support')
+    throw new Error('Please use a browser with webcrypto support and ensure the code has been delivered securely via HTTPS/TLS and run within a Secure Context')
   }
 
   return (data, callback) => {


### PR DESCRIPTION
### Background

> Chrome won't allow access to webcrypto for pages  served via HTTP unless it's at `localhost`. 
This means parts of `window.ipfs`  will be broken on non-TLS non-localhost gateways.
> – https://github.com/ipfs-shipyard/ipfs-companion/issues/475

#### Rationale

Current error can be confusing as Chrome _does_ have webcrypto support, but it is not available on non-TLS HTTP sites.  A developer may opt-in to use a webcrypto-shim in such case, but it takes some time with google to realize what is happening in the first place. Improved Error improves UX by introducing the concept of secure context as a second thing to check.

### Related issues
- https://github.com/ipfs-shipyard/ipfs-webui/issues/653
- https://github.com/ipfs-shipyard/ipfs-webui/issues/637#issuecomment-374778804
- [js-multihashing-async#22](https://github.com/multiformats/js-multihashing-async/issues/22)