### PR TITLE
use process.nextTick instead of setImmediate

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "url": "https://github.com/multiformats/js-multihashing-async/issues"
   },
   "dependencies": {
-    "async": "^2.6.1",
     "blakejs": "^1.1.0",
     "js-sha3": "^0.7.0",
     "multihashes": "~0.4.13",
@@ -63,6 +62,7 @@
     "Harlan T Wood <harlantwood@users.noreply.github.com>",
     "Juan Batiz-Benet <juan@benet.ai>",
     "Marcin Rataj <lidel@lidel.org>",
+    "Matteo Collina <hello@matteocollina.com>",
     "Mitar <mitar.github@tnode.com>",
     "Pedro Teixeira <i@pgte.me>",
     "Richard Littauer <richard.littauer@gmail.com>",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,22 +1,16 @@
 'use strict'
 
-const setImmediate = require('async/setImmediate')
-
 exports.toCallback = (doWork) => {
   return function (input, callback) {
-    const done = (err, res) => setImmediate(() => {
-      callback(err, res)
-    })
-
     let res
     try {
       res = doWork(input)
     } catch (err) {
-      done(err)
+      process.nextTick(callback, err)
       return
     }
 
-    done(null, res)
+    process.nextTick(callback, null, res)
   }
 }
 


### PR DESCRIPTION
I have see this specific setImmediate to cause unneeded latency in https://upload.clinicjs.org/public/1c86eeec6c2c4ee47e0d26d06cec62ee1fe74c745c610d5ba0a11bbe985649aa/31518.clinic-bubbleprof.html.

This happens because other I/O activity happens between the hashing is completed and callback is executed.

This change also removes the closure, having the added benefit of allowing `input` to be garbage collected if possible reducing memory pressure.